### PR TITLE
updated styling for login screen (#117)

### DIFF
--- a/modules/login/Login.tpl
+++ b/modules/login/Login.tpl
@@ -25,25 +25,13 @@
 <p>
 	&nbsp;</p>
 
+
         <div id="contents">
             <div id="login">
-                <?php if (!empty($this->message)): ?>
-                    <div>
-                        <?php if ($this->messageSuccess): ?>
-                            <p class="success"><?php $this->_($this->message); ?><br /></p>
-                        <?php else: ?>
-                            <p class="failure"><?php $this->_($this->message); ?><br /></p>
-                        <?php endif; ?>
-                    </div>
-                <?php endif; ?>
-
                 <div id="loginText">
                     <div class="ctr">
-                        <img src="images/folder1_locked.jpg" width="64" height="64" alt="security" />
                     </div>
                     <br />
-                    <span>Welcome to opencats!</span><br />
-                    <span style="font-size: 10px;">Version <?php echo(CATSUtility::getVersion()); ?></span>
 
                     <?php if (ENABLE_DEMO_MODE && !($this->siteName != '' && $this->siteName != 'choose') || ($this->siteName == 'demo')): ?>
                         <br /><br />
@@ -61,7 +49,8 @@
                 </div>
 
                 <div id="formBlock">
-                    <img src="images/login2.jpg" alt="Login" />
+                    <img src="images/CATS-sig.gif" alt="Login" hspace="10" vspace="10" />
+                    <br />
                     <form name="loginForm" id="loginForm" action="<?php echo(CATSUtility::getIndexName()); ?>?m=login&amp;a=attemptLogin<?php if ($this->reloginVars != ''): ?>&amp;reloginVars=<?php echo($this->reloginVars); ?><?php endif; ?>" method="post" onsubmit="return checkLoginForm(document.loginForm);" autocomplete="off">
                         <div id="subFormBlock">
                             <?php if ($this->siteName != '' && $this->siteName != 'choose'): ?>
@@ -109,6 +98,8 @@
                             <br /><br />
                         </div>
                     </form>
+                
+                    <span style="line-height: 30px;font-size: 10px;padding-LEFT: 10px;">Version <?php echo(CATSUtility::getVersion()); ?></span>
                 </div>
                 <div style="clear: both;"></div>
             </div>
@@ -135,25 +126,27 @@
                     defaultLogin();
                 <?php endif; ?>
             </script>
-<div>Join the Conversation  - <a href="http://www.opencats.org "><strong>opencats forums</strong></a>.</div>
+
           <p>
 	&nbsp;</p>  
 <p>
 	&nbsp;</p>  
-<p>
-	&nbsp;</p>  
-<p>
-	&nbsp;</p>
-<p>
-	&nbsp;</p>
-<p>
-	&nbsp;</p>
-<p>
-	&nbsp;</p>
+
+	<span style="font-size: 12px;"><a href="http://forums.opencats.org ">opencats support forum</a></span>
+	           <div id="login">
+                <?php if (!empty($this->message)): ?>
+                    <div>
+                        <?php if ($this->messageSuccess): ?>
+                            <p class="success"><?php $this->_($this->message); ?><br /></p>
+                        <?php else: ?>
+                            <p class="failure"><?php $this->_($this->message); ?><br /></p>
+                        <?php endif; ?>
+                    </div>
+                <?php endif; ?>
+	</div>
 	  <div id="footerBlock">
-              
                 <span class="footerCopyright"><?php echo(COPYRIGHT_HTML); ?></span>
-                <div>Based upon original work and Powered by <a href="http://www.catsone.com ">CATS</a>.</div>
+                Based upon original work and Powered by <a href="http://www.catsone.com ">CATS</a>.</div>
             </div>
         </div>
 

--- a/modules/login/login.css
+++ b/modules/login/login.css
@@ -11,7 +11,7 @@
 /*** Begin Generic Tag Rules ***/
 body
 {
-    background: #fff;
+       background: #f1f3f5; 
     padding: 8px 18px 8px 18px;
     margin: 0px;
 }
@@ -40,7 +40,7 @@ form
 
 a:link, a:visited
 {
-    color: #00008b;
+    color: #2f4f88;
     text-decoration: none;
     font: normal normal normal 12px/130% Arial, Tahoma, sans-serif;
 }
@@ -81,8 +81,9 @@ div#headerBlock span#subMainLogo
 
 #footerBlock
 {
-    margin-top: 10px;
-    text-align: center;
+    bottom: 0;
+    position: absolute;
+    font: normal normal normal 12px Arial, Tahoma, sans-serif;
 }
 
 #footerBlock p#footerQuotation
@@ -130,19 +131,32 @@ div#login
     margin-right: auto;
     margin-top: 5em;
     padding: 15px;
-    border: 1px solid #ccc;
-    width: 480px;
-    background: #f1f3f5;
+/*    border: 1px solid #ccc; */
+    width: 288px;
+/*    background: #f1f3f5; */
+    text-align: center;
 }
 
 div#formBlock
 {
-    text-align: left;
+ /*   text-align: left; */
     float: right;
-    width: 60%;
-    display: inline;
+    
+    /* display: inline; */
+    text-align: left; 
+    width:288px;
+    height:266px;
+    -webkit-border-radius: 20px;
+    -moz-border-radius: 20px;
+    border-radius: 20px;
+    /* background-color:#f1f3f5F; */
+        background: #fff; 
+    -webkit-box-shadow: #B3B3B3 6px 6px 6px;
+    -moz-box-shadow: #B3B3B3 6px 6px 6px;
+    box-shadow: #B3B3B3 6px 6px 6px;
 }
-
+    
+    
 div#formBlockNewSite
 {
     text-align: center;
@@ -153,7 +167,7 @@ div#formBlockBelow
 {
     text-align: center;
     float: bottom;
-    width: 60%;
+ /*   width: 60%; */
     display: block;
 }
 


### PR DESCRIPTION
* updated login screen

* cosmetic fixes

- Moved copyright statement to an inconspicuous location; bottom left of screen.
- Muted the HTML link colour.
- Changed the support link to point to opencats forums directly.
- Moved the 'failed login pop-up' to below the login window.

* Update Login.tpl

* Update login.css